### PR TITLE
Apply the clean function to the optional fileName

### DIFF
--- a/lib/YoutubeMp3Downloader.js
+++ b/lib/YoutubeMp3Downloader.js
@@ -53,7 +53,7 @@ class YoutubeMp3Downloader extends EventEmitter {
         let self = this;
         const task = {
             videoId: videoId,
-            fileName: fileName
+            fileName: fileName ? this.cleanFileName(fileName) : fileName
         };
     
         this.downloadQueue.push(task, function (err, data) {


### PR DESCRIPTION
This change ensures that the optional fileName variable contains valid characters.

Reason: the user may extend the video title that they use for the file name. In that case the video title could have characters that are not valid for the operating system.